### PR TITLE
adding docdb alarms:

### DIFF
--- a/deploy/lib/notify.ts
+++ b/deploy/lib/notify.ts
@@ -7,12 +7,14 @@ import { LambdaSubscription } from '@aws-cdk/aws-sns-subscriptions';
 import { Construct, CfnOutput, Stack } from '@aws-cdk/core';
 import { CacclLoadBalancer } from './lb';
 import { CacclService } from './service';
+import { CacclDocDb } from './docdb';
 
 export interface CacclNotificationsProps {
   email?: [string];
   slack?: string;
   service: CacclService;
   loadBalancer: CacclLoadBalancer;
+  docdb?: CacclDocDb;
 }
 
 export class CacclNotifications extends Construct {

--- a/deploy/lib/stack.ts
+++ b/deploy/lib/stack.ts
@@ -120,7 +120,7 @@ export class CacclDeployStack extends Stack {
     });
 
     if (docdb !== null) {
-      dashboard.addDocDbSection(docdb.dbCluster);
+      dashboard.addDocDbSection(docdb);
     }
   }
 }


### PR DESCRIPTION
* alarms for what seem like the relevant metrics
* did some refactoring so that each construct (load balancer, docdb,
  etc) creates it's own metrics which can then be used in both the
  dashboard and alarms