### PR TITLE
DocDb clusters now get their own parameter groups:

### DIFF
--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -42,6 +42,7 @@ if (deployConfig.docDb) {
   stackProps.docDbOptions = {
     instanceType: deployConfig.docDbInstanceType || 'r5.large',
     instanceCount: deployConfig.docDbInstanceCount || 1,
+    profiler: deployConfig.docDbProfiler || false,
   };
 }
 

--- a/deploy/lib/stack.ts
+++ b/deploy/lib/stack.ts
@@ -12,6 +12,7 @@ import { CacclTaskDef, CacclTaskDefProps } from './taskdef';
 export interface CacclDocDbOptions {
   instanceType: string;
   instanceCount: number;
+  profiler: boolean;
 }
 
 export interface CacclDeployStackProps extends StackProps {


### PR DESCRIPTION
* uses all default parameters
* `deployConfig.docDbProfiling` boolean allows enabling profiler