### PR TITLE
version generation incorrectly detecting if running in a git repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.7.1] - 2021-08-12
+
+### Fixed
+
+- version generation incorrectly detecting if programming running from a git repo
+
 ## [0.7.0] - 2021-08-11, porta deployment changes
 
 ### Fixed
@@ -87,7 +93,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.4.0]
 ## [0.3.0]
 
-[unreleased]: https://github.com/harvard-edtech/caccl-deploy/compare/v0.7.0...HEAD
+[unreleased]: https://github.com/harvard-edtech/caccl-deploy/compare/v0.7.1...HEAD
+[0.7.1]: https://github.com/harvard-edtech/caccl-deploy/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/harvard-edtech/caccl-deploy/compare/v0.6.4...v0.7.0
 [0.6.4]: https://github.com/harvard-edtech/caccl-deploy/compare/v0.6.3...v0.6.4
 [0.6.3]: https://github.com/harvard-edtech/caccl-deploy/compare/v0.6.2...v0.6.3

--- a/lib/generateVersion.js
+++ b/lib/generateVersion.js
@@ -22,10 +22,10 @@ module.exports = () => {
   // are we in a git repo?
   let inGitRepo = false;
   try {
-    const isInsideWorkTree = getCommandResult(
-      'git rev-parse --is-inside-work-tree'
+    const gitLsThisFile = getCommandResult(
+      `git ls-files ${__filename}`
     );
-    inGitRepo = isInsideWorkTree === 'true';
+    inGitRepo = gitLsThisFile !== '';
   } catch (err) {
     // error will be captialized depending on version of git
     if (!err.message.toLowerCase().includes('not a git repository')) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,11 +1,11 @@
 {
   "name": "caccl-deploy",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "ISC",
       "dependencies": {
         "@aws-cdk/aws-cloudwatch": "~1.88.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "caccl-deploy",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "A cli tool for managing ECS/Fargate app deployments",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
when running in a nodenv environment the `git rev-parse ...` process
would traverse up the tree until it found `~/.nodenv/.git` and return
a false positive