### PR TITLE
new `connect` subcommand options:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - scheduled tasks: managed with new `schedule` subcommand, and executed using CloudWatch Events and a Lambda function
+- new `connect` subcommand options:
+    - `-q` / `--quiet` - only output the ssh tunnel command (suitable for wrapping in a shell script)
+    - `-S` / `--sleep` - increase/decrease the amount of time the tunnel will stay open waiting for activity (e.g. a client connection)
 
 ## [0.7.4] - 2021-08-13
 

--- a/README.md
+++ b/README.md
@@ -686,18 +686,31 @@ For connecting to peripheral services, like the DocumentDb or RDS/Mysql database
 - `-l`/`--list` - list the services available to connect to
 - `-s` / `--service` - service to connect to; use `--list` to see what is available
 - `-k` / `--public-key` - path to the ssh public key file to use (default: "~/.ssh/id_rsa.pub")
+- `-q` / `--quiet` - restrict output to only the ssh tunnel command
+- `-S` / `--sleep` - sleep for this many seconds as the tunnel "keepalive" command (default: 60)
 - `--local-port` - attach tunnel to a non-default local port
 
 ##### example
 
-You want to see what services are available to connect to, and then connect to MySQL. You already have MySQL running locally, so for this example we will bind the tunnel to the local port, 3307 (instead of the default 3306):
+You want to see what services are available to connect to, and then connect to MySQL. You already have MySQL running locally, so for this example we will bind the tunnel to the local port, 3307 (instead of the default 3306). You also want to give yourself several minutes to establish a client connection, so bump the "sleep" value to 300 seconds.
 
 ```
 $ caccl-deploy connect -a my-app --list
 Valid `--service=` options:
   mysql
   redis
-$ caccl-deploy connect -a my-app -s mysql --local-port 3307
+$ caccl-deploy connect -a my-app -s mysql --local-port 3307 --sleep 300
+```
+
+Output:
+```
+Your public key, /home/foo/.ssh/id_rsa.pub, has temporarily been placed on the bastion instance
+You have ~60s to establish the ssh tunnel
+
+# tunnel command:
+ssh -f -L 3307:my-app-db-cluster.cluster-cnrqypmjblyx.us-east-1.rds.amazonaws.com:3306 -o StrictHostKeyChecking=no ec2-user@12.34.56.78 sleep 300
+# mysql client command:
+mysql -uroot -pxxxxxxxxxx --port 3307 -h 127.0.0.1
 ```
 
 ---

--- a/index.js
+++ b/index.js
@@ -943,6 +943,12 @@ async function main() {
       untildify('~/.ssh/id_rsa.pub')
     )
     .option('--local-port <string>', 'attach tunnel to a non-default local port')
+    .option('-q, --quiet', 'output only the ssh tunnel command')
+    .option(
+      '-S, --sleep <string>',
+      'keep the tunnel alive for this long without activity',
+      60
+    )
     .action(async (cmd) => {
       if (!cmd.list && !cmd.service) {
         exitWithError("One of `--list` or `--service` is required");
@@ -1023,8 +1029,12 @@ async function main() {
         `${cmd.localPort || localPort}:${endpoint}`,
         '-o StrictHostKeyChecking=no',
         `${aws.EC2_INSTANCE_CONNECT_USER}@${bastionHostIp}`,
-        'sleep 60',
+        `sleep ${cmd.sleep}`,
       ].join(' ');
+
+      if (cmd.quiet) {
+        exitWithSuccess(tunnelCommand);
+      }
 
       exitWithSuccess([
         `Your public key, ${cmd.publicKey}, has temporarily been placed on the bastion instance`,


### PR DESCRIPTION
- `-q` / `--quiet` - only output the ssh tunnel command (suitable for wrapping in a shell script)
- `-S` / `--sleep` - increase/decrease the amount of time the tunnel will stay open waiting for activity (e.g. a client connection)