### PR TITLE
don't name the Fargate service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Changed
+
+- no longer assigning a name to the Fargate Service as it would in some cases cause name collision errors when CloudFormation needed to replace the resource. As a result the service names will be something like:
+     - "CacclDeploy-foo-app-EcsServiceFargateServiceF382E1EB-pbHI10hubZdS"
+     - instead of "CacclDeploy-foo-app-service"
+
 ## [0.8.0] - 2021-09-14
 
 ### Added

--- a/cdk/lib/service.ts
+++ b/cdk/lib/service.ts
@@ -23,11 +23,9 @@ export class CacclService extends Construct {
     super(scope, id);
 
     const { sg, cluster, taskDef, taskCount } = props;
-    const serviceName = `${Stack.of(this).stackName}-service`;
 
     this.ecsService = new FargateService(this, 'FargateService', {
       cluster,
-      serviceName,
       platformVersion: FargatePlatformVersion.VERSION1_3,
       securityGroup: sg,
       taskDefinition: taskDef.taskDef,
@@ -54,7 +52,7 @@ export class CacclService extends Construct {
 
     new CfnOutput(this, 'ServiceName', {
       exportName: `${Stack.of(this).stackName}-service-name`,
-      value: serviceName,
+      value: this.ecsService.serviceName,
     });
   }
 }


### PR DESCRIPTION
it causes naming collisions when CloudFormation wants to replace the
resource.