### PR TITLE
small fixes to the `new` proccess:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixed
+
+- "main" is now considered a primary branch name when fetching a list of available ECR images
+- during the `new` command process, the error thrown when there are no valid image tags has a more informative message
+
 ## [0.9.0] - 2021-09-17
 
 ### Added

--- a/lib/aws.js
+++ b/lib/aws.js
@@ -262,7 +262,7 @@ const aws = {
       // find the latest semver tagged image
       return images.filter((i) => {
         return i.imageTags.some((t) => {
-          return looksLikeSemver(t) || ['master', 'stage'].includes(t);
+          return looksLikeSemver(t) || ['main', 'master', 'stage'].includes(t);
         });
       });
     }

--- a/lib/configPrompts.js
+++ b/lib/configPrompts.js
@@ -190,6 +190,10 @@ const promptFuncs = {
           return choices;
         }, []);
 
+        if (!imageTagsChoices.length) {
+          throw new NoPromptChoices('No valid image tags to choose from');
+        }
+
         const imageTagChoice = await prompt({
           type: 'select',
           name: 'value',


### PR DESCRIPTION
- recognize 'main' as a primary branch name
- informative message if no valid image tags are found for a repo