### PR TITLE
a couple of fixes to the cdk subprocess:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Changed
+
+- `stack` subcommand now uses explicit path to the `cdk` executable instead of `npx`
+- `cdk.json` app configuration now uses explicit path to `ts-node` executable instead of `npx`
+
+### Added
+
+- `stack` subcommand now sets `CDK_DISABLE_VERSION_CHECK` to supress the "newer version available" messages.
+
 ## [0.9.1] - 2021-09-21
 
 ### Fixed

--- a/cdk.json
+++ b/cdk.json
@@ -1,5 +1,5 @@
 {
-  "app": "npx --no-install ts-node cdk/index.ts",
+  "app": "node_modules/.bin/ts-node cdk/index.ts",
   "context": {
     "aws-cdk:enableDiffNoFail": "true"
   }

--- a/index.js
+++ b/index.js
@@ -656,6 +656,7 @@ async function main() {
 
       const envAdditions = {
         AWS_REGION: process.env.AWS_REGION || 'us-east-1',
+        CDK_DISABLE_VERSION_CHECK: true,
       };
 
       // all args/options following the `stack` subcommand get passed to cdk
@@ -721,7 +722,7 @@ async function main() {
         };
 
         try {
-          execSync(['npx cdk', ...cdkArgs].join(' '), execOpts);
+          execSync(['node_modules/.bin/cdk', ...cdkArgs].join(' '), execOpts);
           exitWithSuccess('done!');
         } catch (err) {
           exitWithError(err.msg);


### PR DESCRIPTION
- use explicit paths to executables (instead of `npx`)
- set `CDK_DISABLE_VERSION_CHECK` to supress version upgrade messages