### PR TITLE
redo of db cluster/instance metrics

### DIFF
--- a/cdk/lib/notify.ts
+++ b/cdk/lib/notify.ts
@@ -5,7 +5,7 @@ import { Function, Runtime, Code } from '@aws-cdk/aws-lambda';
 import { Topic, Subscription, SubscriptionProtocol } from '@aws-cdk/aws-sns';
 import { LambdaSubscription } from '@aws-cdk/aws-sns-subscriptions';
 import { Construct, CfnOutput, Stack } from '@aws-cdk/core';
-import { CacclDb, CacclDocDb, CacclRdsDb } from './db';
+import { CacclDocDb, CacclRdsDb } from './db';
 import { CacclLoadBalancer } from './lb';
 import { CacclService } from './service';
 

--- a/cdk/lib/stack.ts
+++ b/cdk/lib/stack.ts
@@ -4,7 +4,7 @@ import { Stack, Construct, StackProps } from '@aws-cdk/core';
 
 import { CacclAppEnvironment } from './appEnvironment';
 import { CacclMonitoring } from './dashboard';
-import { CacclDbOptions, CacclDb } from './db';
+import { CacclDbOptions, CacclDbBase } from './db';
 import { CacclLoadBalancer } from './lb';
 import { CacclNotifications, CacclNotificationsProps } from './notify';
 import { CacclCache, CacclCacheOptions } from './cache';
@@ -70,7 +70,7 @@ export class CacclDeployStack extends Stack {
     let db = null;
     if (props.dbOptions) {
       createBastion = true;
-      db = CacclDb.createDbConstruct(this, {
+      db = CacclDbBase.createDbConstruct(this, {
         vpc,
         options: props.dbOptions,
         appEnv,


### PR DESCRIPTION
- push generation of metrics and alarms down to the subclasses as the
  metrics come from different places: docdb metrics from the cluster,
  rds/mysq come from the instances
- rearranging the db section of the dashboard somewhat to accomodate the
  busier rds/mysql widgets
- set `innodb_monitor_enable='all'` on the rds/mysql instances so that
  we can get the "ActiveTransactions" metric.