### PR TITLE
several changes for release v0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Modified
 
 - updated the alarm threshold docdb cursor timeouts. Instead of firing on each occurrance it now has to see 5 over 5 minutes for 3 consectuive evaluation periods.
+- update to Fargate platform version 1.4
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fixed two files related to task scheduling that were somehow formatted with tabs instead of spaces
 - tags are now propagated from the ECS service to the Fargate tasks
 
+### Added
+
+- new deploy configuration setting: `targetDeregistrationDelay`, specifies number of seconds between when load balancer stops sending new reguests to a target and the target is finally deregistered.
+
 ## [0.10.3] - 2021-09-29
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Modified
+
+- updated the alarm threshold docdb cursor timeouts. Instead of firing on each occurrance it now has to see 5 over 5 minutes for 3 consectuive evaluation periods.
+
 ### Fixed
 
 - fixed two files related to task scheduling that were somehow formatted with tabs instead of spaces

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - new deploy configuration setting: `targetDeregistrationDelay`, specifies number of seconds between when load balancer stops sending new reguests to a target and the target is finally deregistered.
+- new configuration setting, `firewallSgId` allows for importing a security group to apply to the load balancer and bastion host. meant as a way to restrict app traffic to internal (office, vpn) ips.
 
 ## [0.10.3] - 2021-09-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.11.0] - 2022-02-22
+
 ### Modified
 
 - updated the alarm threshold docdb cursor timeouts. Instead of firing on each occurrance it now has to see 5 over 5 minutes for 3 consectuive evaluation periods.
@@ -211,7 +213,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.4.0]
 ## [0.3.0]
 
-[unreleased]: https://github.com/harvard-edtech/caccl-deploy/compare/v0.10.3...HEAD
+[unreleased]: https://github.com/harvard-edtech/caccl-deploy/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/harvard-edtech/caccl-deploy/compare/v0.10.3...v0.11.0
 [0.10.3]: https://github.com/harvard-edtech/caccl-deploy/compare/v0.10.2...v0.10.3
 [0.10.2]: https://github.com/harvard-edtech/caccl-deploy/compare/v0.10.1...v0.10.2
 [0.10.1]: https://github.com/harvard-edtech/caccl-deploy/compare/v0.10.0...v0.10.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - fixed two files related to task scheduling that were somehow formatted with tabs instead of spaces
+- tags are now propagated from the ECS service to the Fargate tasks
 
 ## [0.10.3] - 2021-09-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixed
+
+- fixed two files related to task scheduling that were somehow formatted with tabs instead of spaces
+
 ## [0.10.3] - 2021-09-29
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ _**Important**_: The configured address(es) will redceive a confirmation message
 
 `taskMemory` - memory in MB assigned to each task. Default is "512". See note below.
 
+`targetDeregistrationDelay` - number of seconds between when the load balancer stops sending requests to a target (i.e. an app task instance) and when it actually deregisters the target. See [Deregistration Delay](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html#deregistration-delay).
+
 `gitRepoVolume` - You can ignore this unless you have the very edge case situation in which your app needs a private git repo to be checked out to an attached volume. In which case set the mount path with `appContainerPath` and the `repoUrlSecretArn` with the ARN of a SecretsManager entry containing the full url of the github repo, including username and password.
 
 **Database & cache options**

--- a/README.md
+++ b/README.md
@@ -225,21 +225,21 @@ The following DocumentDb configuration was used by caccl-deploy prior to version
 
 First the required values.
 
-`infraStackName` - this tells `caccl-deploy` what set of shared infrastructure resources your app will be deployed into. For this setting you just want the string value of the CloudFormation stack name. The companion project, [dce-ecs-infra](https://github.com/harvard-edtech/dce-ecs-infra) is what we use to build out that infrastructure.
+`infraStackName` (string) - this tells `caccl-deploy` what set of shared infrastructure resources your app will be deployed into. For this setting you just want the string value of the CloudFormation stack name. The companion project, [dce-ecs-infra](https://github.com/harvard-edtech/dce-ecs-infra) is what we use to build out that infrastructure.
 
-`appImage` - this tells `caccl-deploy` where to find your app's Docker image. This value should be the ARN of an ECR repo plus an image tag. It's also possible to use a DockerHub name:tag combo, but some of the `caccl-deploy` subcommands (`release` for example) are not compatible with that use.
+`appImage` (string) - this tells `caccl-deploy` where to find your app's Docker image. This value should be the ARN of an ECR repo plus an image tag. It's also possible to use a DockerHub name:tag combo, but some of the `caccl-deploy` subcommands (`release` for example) are not compatible with that use.
 
-`certificateArn` - one of the components of the app provisioning that `caccl-deploy` creates is a Application Load Balancer. You will need to create (or import) an ACM certificate so that it can be attached to the load balancer. This value should be the full ARN of that certfiicate.
+`certificateArn` (string) - one of the components of the app provisioning that `caccl-deploy` creates is a Application Load Balancer. You will need to create (or import) an ACM certificate so that it can be attached to the load balancer. This value should be the full ARN of that certfiicate.
 
 Now the optional stuff.
 
-`firewallSgId` - set this to import/re-use an existing security group that will be applied to the load balancer and bastion host. See "Secruity" below.
+`firewallSgId` (string) - set this to import/re-use an existing security group that will be applied to the load balancer and bastion host. See "Security" below.
 
-`appEnvironment` - a set of key value pairs that will be injected into your app's runtime container environment. You'll probably have some of these. Note that the actual values of these are always stored as SecretsManager entries, and your ECS Fargate Task Definition will be created with the ARN values of those secrets. `caccl-deploy` manages the registering/resolving for you, so when you run `caccl-deploy show --app my-app` the output will contain the raw, dereferenced strings. You can add the `--keep-secret-arns` flag to see the actual ARN values.
+`appEnvironment` ({ [string]: string }) - a set of key value pairs that will be injected into your app's runtime container environment. You'll probably have some of these. Note that the actual values of these are always stored as SecretsManager entries, and your ECS Fargate Task Definition will be created with the ARN values of those secrets. `caccl-deploy` manages the registering/resolving for you, so when you run `caccl-deploy show --app my-app` the output will contain the raw, dereferenced strings. You can add the `--keep-secret-arns` flag to see the actual ARN values.
 
-`notifications.slack` - a slack webhook URL. If configured this will result in a Lambda function being added to your stack and subscribed to the stack's SNS topic for alert notifications.
+`notifications.slack` (string) - a slack webhook URL. If configured this will result in a Lambda function being added to your stack and subscribed to the stack's SNS topic for alert notifications.
 
-`notifications.email` - an email address for subscribing to the stack's SNS topic for alerts and other notifications. This setting also supports a list of addresses, which would be represented as `notifications.email.[0-n]`. In other words, the following configuration is also supported:
+`notifications.email` ([string])- an email address for subscribing to the stack's SNS topic for alerts and other notifications. This setting also supports a list of addresses, which would be represented as `notifications.email.[0-n]`. In other words, the following configuration is also supported:
 
 ```
 {
@@ -251,25 +251,25 @@ Now the optional stuff.
   }
 }
 ```
-_**Important**_: The configured address(es) will redceive a confirmation message and must confirm to complete the subscription.
+_**Important**_: The configured address(es) will receive a confirmation message and must confirm to complete the subscription.
 
-`tags` - a set of key value pairs. these will be assigned to the CloudFormation stack and by extension all the resources in the stack (for resource types that support this (which is most)).
+`tags` ({ [string]: string }) - a set of key value pairs. these will be assigned to the CloudFormation stack and by extension all the resources in the stack (for resource types that support this (which is most)).
 
-`taskCount` - how many concurrent tasks should the Fargate service run. Default is "1".
+`taskCount` (number) - how many concurrent tasks should the Fargate service run. Default is "1".
 
-`taskCpu` - the amount of CPU units assigned to each task. Default is "256", which is equivalent to 1 virtual CPU (vCPU). See note below.
+`taskCpu` (number) - the amount of CPU units assigned to each task. Default is "256", which is equivalent to 1 virtual CPU (vCPU). See note below.
 
-`taskMemory` - memory in MB assigned to each task. Default is "512". See note below.
+`taskMemory` (number) - memory in MB assigned to each task. Default is "512". See note below.
 
-`targetDeregistrationDelay` - number of seconds between when the load balancer stops sending requests to a target (i.e. an app task instance) and when it actually deregisters the target. See [Deregistration Delay](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html#deregistration-delay).
+`targetDeregistrationDelay` (number) - number of seconds between when the load balancer stops sending requests to a target (i.e. an app task instance) and when it actually deregisters the target. See [Deregistration Delay](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html#deregistration-delay).
 
-`gitRepoVolume` - You can ignore this unless you have the very edge case situation in which your app needs a private git repo to be checked out to an attached volume. In which case set the mount path with `appContainerPath` and the `repoUrlSecretArn` with the ARN of a SecretsManager entry containing the full url of the github repo, including username and password.
+`gitRepoVolume` (string) - You can ignore this unless you have the very edge case situation in which your app needs a private git repo to be checked out to an attached volume. In which case set the mount path with `appContainerPath` and the `repoUrlSecretArn` with the ARN of a SecretsManager entry containing the full url of the github repo, including username and password.
 
 **Database & cache options**
 
-`dbOptions.engine` - Allowed values are "mysql" and "docdb". If set, a cluster of the specified type will be provisioned and its connection details and credentials injected into the container environment. See the Database section below for more info.
+`dbOptions.engine` (string) - Allowed values are "mysql" and "docdb". If set, a cluster of the specified type will be provisioned and its connection details and credentials injected into the container environment. See the Database section below for more info.
 
-`cacheOptions.engine` - "redis" is the only supported value. If set, an Elasticache instance will be provisioned and its connection details injected into the container environment. See the Cache section below for more info.
+`cacheOptions.engine` (string) - "redis" is the only supported value. If set, an Elasticache instance will be provisioned and its connection details injected into the container environment. See the Cache section below for more info.
 
 ##### A note about `taskCpu` and `taskMemory`
 
@@ -365,23 +365,23 @@ The `caccl-deploy connect ...` command can be used for creating ssh port-forward
 
 ##### Common db options
 
-`dbOptions.engine` - either "mysql" or "docdb"
+`dbOptions.engine` (string) - either "mysql" or "docdb"
 
-`dbOptions.instanceType` - default is "t3.medium". Consider at least "r5.large" for production.
+`dbOptions.instanceType` (string) - default is "t3.medium". Consider at least "r5.large" for production.
 
-`dbOptions.instanceCount` - Default is "1". Production apps should use "2" to enable multi-az replication.
+`dbOptions.instanceCount` (number) - Default is "1". Production apps should use "2" to enable multi-az replication.
 
-`dbOptions.engineVersion` - use a specific version of the docdb or aurora/mysql engine. You probably don't need to set this.
+`dbOptions.engineVersion` (string) - use a specific version of the docdb or aurora/mysql engine. You probably don't need to set this.
 
-`dbOptions.removalPolicy` - **IMPORTANT** can be one of "RETAIN", "SNAPSHOT" or "DELETE". See the section just below on what this does.
+`dbOptions.removalPolicy` (string) - **IMPORTANT** can be one of "RETAIN", "SNAPSHOT" or "DELETE". See the section just below on what this does.
 
 ##### DocumentDb only
 
-`dbOptions.profiler` - Enable the DocDB cluster's slow query profiling option. The default threshold for what's considered a slow query is 500ms.
+`dbOptions.profiler` ("true|false") - Enable the DocDB cluster's slow query profiling option. The default threshold for what's considered a slow query is 500ms.
 
 ##### Mysql only
 
-`dbOptions.databaseName` - Set this if you want a database to be automatically created during provisioning.
+`dbOptions.databaseName` (string) - Set this if you want a database to be automatically created during provisioning.
 
 ##### DocumentDb environment variables
 
@@ -440,11 +440,11 @@ Including a cache in your deploy configuration will result in a bastion host bei
 
 ##### Cache options
 
-`cacheOptions.engine` - currently the only choice is "redis"
+`cacheOptions.engine` (string) - currently the only choice is "redis"
 
-`cacheOptions.numCacheNodes` - Default is "1". Production apps should use "2" to enable multi-az replication.
+`cacheOptions.numCacheNodes` (number) - Default is "1". Production apps should use "2" to enable multi-az replication.
 
-`cacheOptions.cacheNodeType` - Default is "cache.t3.medium". Consider "cache.r5.large" for production.
+`cacheOptions.cacheNodeType` (string) - Default is "cache.t3.medium". Consider "cache.r5.large" for production.
 
 ---
 

--- a/cdk/assets/scheduled_task_exec/index.js
+++ b/cdk/assets/scheduled_task_exec/index.js
@@ -7,32 +7,32 @@ const ECS_TASK_DEFINITION = process.env.ECS_TASK_DEFINITION;
 const ecs = new aws.ECS();
 
 exports.handler = async (event, context) => {
-	const { execCommand = 'python manage.py check' } = event;
+  const { execCommand = 'python manage.py check' } = event;
 
-	const serviceResp = await ecs
-		.describeServices({
-			cluster: ECS_CLUSTER,
-			services: [ECS_SERVICE],
-		}).promise();
-	const service = serviceResp.services[0];
+  const serviceResp = await ecs
+    .describeServices({
+      cluster: ECS_CLUSTER,
+      services: [ECS_SERVICE],
+    }).promise();
+  const service = serviceResp.services[0];
 
-	const { networkConfiguration } = service;
+  const { networkConfiguration } = service;
 
-	const execResp = await ecs.runTask({
-		cluster: ECS_CLUSTER,
-		taskDefinition: ECS_TASK_DEFINITION,
-		networkConfiguration,
-		launchType: 'FARGATE',
-		platformVersion: '1.3.0',
-		overrides: {
-			containerOverrides: [
-				{
-					name: 'AppOnlyContainer',
-					command: ['/bin/sh', '-c', execCommand],
-				}
-			],
-		},
-	}).promise();
-	const { taskArn } = execResp.tasks[0];
-	console.log(`Task ${taskArn} started`);
+  const execResp = await ecs.runTask({
+    cluster: ECS_CLUSTER,
+    taskDefinition: ECS_TASK_DEFINITION,
+    networkConfiguration,
+    launchType: 'FARGATE',
+    platformVersion: '1.3.0',
+    overrides: {
+      containerOverrides: [
+        {
+          name: 'AppOnlyContainer',
+          command: ['/bin/sh', '-c', execCommand],
+        }
+      ],
+    },
+  }).promise();
+  const { taskArn } = execResp.tasks[0];
+  console.log(`Task ${taskArn} started`);
 }

--- a/cdk/index.ts
+++ b/cdk/index.ts
@@ -47,6 +47,7 @@ const stackProps: CacclDeployStackProps = {
   },
   taskCount: +(deployConfig.taskCount || 1),
   targetDeregistrationDelay: deployConfig.targetDeregistrationDelay,
+  firewallSgId: deployConfig.firewallSgId,
   cacheOptions: deployConfig.cacheOptions,
   dbOptions: deployConfig.dbOptions,
   bastionAmiMap: deployConfig.bastionAmiMap || {},

--- a/cdk/index.ts
+++ b/cdk/index.ts
@@ -46,6 +46,7 @@ const stackProps: CacclDeployStackProps = {
     gitRepoVolume: deployConfig.gitRepoVolume,
   },
   taskCount: +(deployConfig.taskCount || 1),
+  targetDeregistrationDelay: deployConfig.targetDeregistrationDelay,
   cacheOptions: deployConfig.cacheOptions,
   dbOptions: deployConfig.dbOptions,
   bastionAmiMap: deployConfig.bastionAmiMap || {},

--- a/cdk/lib/bastion.ts
+++ b/cdk/lib/bastion.ts
@@ -7,31 +7,27 @@ const DEFAULT_AMI_MAP = {
 
 export interface CacclSshBastionProps {
   vpc: Vpc,
+  sg: SecurityGroup;
   amiMap?: { [key: string]: string },
 };
 
 export class CacclSshBastion extends Construct {
   instance: BastionHostLinux;
-  sg: SecurityGroup;
 
   constructor(scope: Construct, id: string, props: CacclSshBastionProps) {
     super(scope, id);
 
     const {
       vpc,
+      sg,
       amiMap = {},
     } = props;
-
-
-
-    this.sg = new SecurityGroup(this, 'BastionSecurityGroup', { vpc });
-    this.sg.addIngressRule(Peer.anyIpv4(), Port.tcp(22));
 
     this.instance = new BastionHostLinux(this, 'SshBastionHost', {
       vpc,
       subnetSelection: { subnetType: SubnetType.PUBLIC },
       instanceName: `${Stack.of(this).stackName}-bastion`,
-      securityGroup: this.sg,
+      securityGroup: sg,
       machineImage: MachineImage.genericLinux(Object.assign(DEFAULT_AMI_MAP, amiMap)),
     });
 

--- a/cdk/lib/db.ts
+++ b/cdk/lib/db.ts
@@ -282,8 +282,9 @@ export class CacclDocDb extends CacclDbBase {
       }),
       new Alarm(this, 'DatabaseCursorsTimedOutAlarm', {
         metric: this.metrics.DatabaseCursorsTimedOut[0],
-        threshold: 1,
-        evaluationPeriods: 1,
+        threshold: 5,
+        period: Duration.minutes(5),
+        evaluationPeriods: 3,
         alarmDescription: `${Stack.of(this).stackName} docdb cursors timed out alarm`,
       }),
     ];

--- a/cdk/lib/lb.ts
+++ b/cdk/lib/lb.ts
@@ -18,7 +18,7 @@ export interface CacclLoadBalancerProps {
   certificateArn: string;
   loadBalancerTarget: IEcsLoadBalancerTarget;
   albLogBucketName?: string;
-  targetDeregistrationDelay?: number;
+  targetDeregistrationDelay?: number; // in seconds
 }
 
 export class CacclLoadBalancer extends Construct {

--- a/cdk/lib/lb.ts
+++ b/cdk/lib/lb.ts
@@ -13,8 +13,8 @@ import { Bucket } from '@aws-cdk/aws-s3';
 import { CfnOutput, Construct, Duration, Stack } from '@aws-cdk/core';
 
 export interface CacclLoadBalancerProps {
-  sg: SecurityGroup;
   vpc: Vpc;
+  sg: SecurityGroup;
   certificateArn: string;
   loadBalancerTarget: IEcsLoadBalancerTarget;
   albLogBucketName?: string;
@@ -34,8 +34,8 @@ export class CacclLoadBalancer extends Construct {
     super(scope, id);
 
     const {
-      sg,
       vpc,
+      sg,
       certificateArn,
       loadBalancerTarget,
       albLogBucketName,
@@ -78,6 +78,11 @@ export class CacclLoadBalancer extends Construct {
       certificates: [{ certificateArn }],
       port: 443,
       protocol: ApplicationProtocol.HTTPS,
+      /**
+       * if we don't make this false the listener construct will add rules
+       * to our security group that we don't want/need
+       */
+      open: false,
     });
 
     const appTargetGroup = new ApplicationTargetGroup(this, 'TargetGroup', {
@@ -98,9 +103,6 @@ export class CacclLoadBalancer extends Construct {
     httpsListener.addTargetGroups('AppTargetGroup', {
       targetGroups: [appTargetGroup],
     });
-
-    sg.addIngressRule(Peer.anyIpv4(), Port.tcp(80));
-    sg.addIngressRule(Peer.anyIpv4(), Port.tcp(443));
 
     this.metrics = {
       RequestCount: this.loadBalancer.metricRequestCount(),

--- a/cdk/lib/lb.ts
+++ b/cdk/lib/lb.ts
@@ -18,6 +18,7 @@ export interface CacclLoadBalancerProps {
   certificateArn: string;
   loadBalancerTarget: IEcsLoadBalancerTarget;
   albLogBucketName?: string;
+  targetDeregistrationDelay?: number;
 }
 
 export class CacclLoadBalancer extends Construct {
@@ -32,7 +33,14 @@ export class CacclLoadBalancer extends Construct {
   constructor(scope: Construct, id: string, props: CacclLoadBalancerProps) {
     super(scope, id);
 
-    const { sg, vpc, certificateArn, loadBalancerTarget, albLogBucketName } = props;
+    const {
+      sg,
+      vpc,
+      certificateArn,
+      loadBalancerTarget,
+      albLogBucketName,
+      targetDeregistrationDelay = 30,
+    } = props;
 
     this.loadBalancer = new ApplicationLoadBalancer(this, 'LoadBalancer', {
       vpc,
@@ -78,7 +86,7 @@ export class CacclLoadBalancer extends Construct {
       protocol: ApplicationProtocol.HTTPS,
       // setting this duration value enables the lb stickiness; 1 day is the default
       stickinessCookieDuration: Duration.seconds(86400),
-      deregistrationDelay: Duration.seconds(30),
+      deregistrationDelay: Duration.seconds(targetDeregistrationDelay),
       targetType: TargetType.IP,
       targets: [loadBalancerTarget],
       healthCheck: {

--- a/cdk/lib/scheduledTasks.ts
+++ b/cdk/lib/scheduledTasks.ts
@@ -10,132 +10,132 @@ import { FargateTaskDefinition } from '@aws-cdk/aws-ecs';
 import { Alarm, ComparisonOperator } from '@aws-cdk/aws-cloudwatch';
 
 export interface CacclScheduledTask {
-	description?: string,
-	schedule: string,
-	command: string,
+  description?: string,
+  schedule: string,
+  command: string,
 };
 
 export interface CacclScheduledTasksProps {
-	vpc: Vpc,
-	scheduledTasks: { [key: string]: CacclScheduledTask },
-	clusterName: string,
-	serviceName: string,
-	taskDefinition: FargateTaskDefinition,
+  vpc: Vpc,
+  scheduledTasks: { [key: string]: CacclScheduledTask },
+  clusterName: string,
+  serviceName: string,
+  taskDefinition: FargateTaskDefinition,
 };
 
 export class CacclScheduledTasks extends Construct {
-	taskExecFunction: Function;
+  taskExecFunction: Function;
 
-	eventRules: Rule[] = [];
+  eventRules: Rule[] = [];
 
-	alarms: Alarm[] = [];
+  alarms: Alarm[] = [];
 
-	constructor(scope: Construct, id: string, props: CacclScheduledTasksProps) {
-		super(scope, id);
+  constructor(scope: Construct, id: string, props: CacclScheduledTasksProps) {
+    super(scope, id);
 
-		const {
-			stackName,
-			region,
-			account,
-		} = Stack.of(this);
+    const {
+      stackName,
+      region,
+      account,
+    } = Stack.of(this);
 
-		const {
-			clusterName,
-			serviceName,
-			taskDefinition,
-			vpc,
-			scheduledTasks,
-		} = props;
+    const {
+      clusterName,
+      serviceName,
+      taskDefinition,
+      vpc,
+      scheduledTasks,
+    } = props;
 
-		this.taskExecFunction = new Function(this, 'ScheduledTaskExecFunction', {
-			functionName: `${stackName}-scheduled-task-exec`,
-			runtime: Runtime.NODEJS_12_X,
-			handler: 'index.handler',
-			code: Code.fromAsset(path.join(__dirname, '..', 'assets/scheduled_task_exec')),
-			vpc,
-			vpcSubnets: { subnetType: SubnetType.PRIVATE },
-			environment: {
-				ECS_CLUSTER: clusterName,
-				ECS_SERVICE: serviceName,
-				ECS_TASK_DEFINITION: taskDefinition.family,
-			},
-		});
+    this.taskExecFunction = new Function(this, 'ScheduledTaskExecFunction', {
+      functionName: `${stackName}-scheduled-task-exec`,
+      runtime: Runtime.NODEJS_12_X,
+      handler: 'index.handler',
+      code: Code.fromAsset(path.join(__dirname, '..', 'assets/scheduled_task_exec')),
+      vpc,
+      vpcSubnets: { subnetType: SubnetType.PRIVATE },
+      environment: {
+        ECS_CLUSTER: clusterName,
+        ECS_SERVICE: serviceName,
+        ECS_TASK_DEFINITION: taskDefinition.family,
+      },
+    });
 
-		// create a cloudwatch event rule for each configured task
-		Object.keys(scheduledTasks).forEach((scheduledTaskId) => {
-			const scheduledTask = scheduledTasks[scheduledTaskId];
-			// the target is always our lambda function, but with variable commands to execute the task with
-			// e.g., "python manage.py some-recurring-job"
-			const eventTarget = new LambdaTarget(this.taskExecFunction, {
-				// this is the json event object that the lambda function receives
-				event: RuleTargetInput.fromObject({
-					execCommand: scheduledTask.command,
-				}),
-			});
-			const schedule = Schedule.expression(`cron(${scheduledTask.schedule})`);
-			const ruleName = `${Stack.of(this)}-scheduled-task-${scheduledTaskId}`;
-			const eventRule = new Rule(this, `ScheduledTaskEventRule${scheduledTaskId}`, {
-				ruleName,
-				schedule,
-				targets: [eventTarget],
-				description: scheduledTask.description,
-			})
-			this.eventRules.push(eventRule);
-		});
+    // create a cloudwatch event rule for each configured task
+    Object.keys(scheduledTasks).forEach((scheduledTaskId) => {
+      const scheduledTask = scheduledTasks[scheduledTaskId];
+      // the target is always our lambda function, but with variable commands to execute the task with
+      // e.g., "python manage.py some-recurring-job"
+      const eventTarget = new LambdaTarget(this.taskExecFunction, {
+        // this is the json event object that the lambda function receives
+        event: RuleTargetInput.fromObject({
+          execCommand: scheduledTask.command,
+        }),
+      });
+      const schedule = Schedule.expression(`cron(${scheduledTask.schedule})`);
+      const ruleName = `${Stack.of(this)}-scheduled-task-${scheduledTaskId}`;
+      const eventRule = new Rule(this, `ScheduledTaskEventRule${scheduledTaskId}`, {
+        ruleName,
+        schedule,
+        targets: [eventTarget],
+        description: scheduledTask.description,
+      })
+      this.eventRules.push(eventRule);
+    });
 
-		// function needs to read various ecs stuff
-		this.taskExecFunction.addToRolePolicy(new PolicyStatement({
-			effect: Effect.ALLOW,
-			actions: [
-				"ecs:Describe*",
-				"ecs:List*",
-			],
-			resources: ["*"],
-		}));
+    // function needs to read various ecs stuff
+    this.taskExecFunction.addToRolePolicy(new PolicyStatement({
+      effect: Effect.ALLOW,
+      actions: [
+        "ecs:Describe*",
+        "ecs:List*",
+      ],
+      resources: ["*"],
+    }));
 
-		// function needs to be able to run our task
-		this.taskExecFunction.addToRolePolicy(new PolicyStatement({
-			effect: Effect.ALLOW,
-			actions: ["ecs:RunTask"],
-			resources: [
-				`arn:aws:ecs:${region}:${account}:task-definition/${taskDefinition.family}`,
-			]
-		}));
+    // function needs to be able to run our task
+    this.taskExecFunction.addToRolePolicy(new PolicyStatement({
+      effect: Effect.ALLOW,
+      actions: ["ecs:RunTask"],
+      resources: [
+        `arn:aws:ecs:${region}:${account}:task-definition/${taskDefinition.family}`,
+      ]
+    }));
 
-		// function needs to be able to pass these roles to ECS
-		const passRoleArns = [taskDefinition.taskRole.roleArn];
-		if (taskDefinition.executionRole) {
-			passRoleArns.push(taskDefinition.executionRole.roleArn);
-		}
-		this.taskExecFunction.addToRolePolicy(new PolicyStatement({
-			effect: Effect.ALLOW,
-			actions: ["iam:PassRole"],
-			resources: passRoleArns,
-		}));
+    // function needs to be able to pass these roles to ECS
+    const passRoleArns = [taskDefinition.taskRole.roleArn];
+    if (taskDefinition.executionRole) {
+      passRoleArns.push(taskDefinition.executionRole.roleArn);
+    }
+    this.taskExecFunction.addToRolePolicy(new PolicyStatement({
+      effect: Effect.ALLOW,
+      actions: ["iam:PassRole"],
+      resources: passRoleArns,
+    }));
 
-		this.alarms = [
-			// alarm on any function errors
-			new Alarm(this, 'ErrorAlarm', {
-				metric: this.taskExecFunction.metricErrors(),
-				threshold: 1,
-				period: Duration.minutes(5),
-				evaluationPeriods: 1,
-				alarmDescription: `${stackName} scheduled task execution error alarm`,
-			}),
-			// alarm if function isn't invoked at least once per day
-			new Alarm(this, 'InvocationsAlarm', {
-				metric: this.taskExecFunction.metricInvocations(),
-				threshold: 1,
-				period: Duration.days(1),
-				evaluationPeriods: 1,
-				alarmDescription: `${stackName} no invocations alarm`,
-				comparisonOperator: ComparisonOperator.LESS_THAN_THRESHOLD,
-			}),
-		];
+    this.alarms = [
+      // alarm on any function errors
+      new Alarm(this, 'ErrorAlarm', {
+        metric: this.taskExecFunction.metricErrors(),
+        threshold: 1,
+        period: Duration.minutes(5),
+        evaluationPeriods: 1,
+        alarmDescription: `${stackName} scheduled task execution error alarm`,
+      }),
+      // alarm if function isn't invoked at least once per day
+      new Alarm(this, 'InvocationsAlarm', {
+        metric: this.taskExecFunction.metricInvocations(),
+        threshold: 1,
+        period: Duration.days(1),
+        evaluationPeriods: 1,
+        alarmDescription: `${stackName} no invocations alarm`,
+        comparisonOperator: ComparisonOperator.LESS_THAN_THRESHOLD,
+      }),
+    ];
 
-		new CfnOutput(this, 'DeployConfigHash', {
-			exportName: `${stackName}-scheduled-tasks-function-name`,
-			value: this.taskExecFunction.functionName,
-		});
-	}
+    new CfnOutput(this, 'DeployConfigHash', {
+      exportName: `${stackName}-scheduled-tasks-function-name`,
+      value: this.taskExecFunction.functionName,
+    });
+  }
 }

--- a/cdk/lib/service.ts
+++ b/cdk/lib/service.ts
@@ -1,6 +1,6 @@
 import { Alarm } from '@aws-cdk/aws-cloudwatch';
 import { SecurityGroup } from '@aws-cdk/aws-ec2';
-import { Cluster, FargatePlatformVersion, FargateService, IEcsLoadBalancerTarget } from '@aws-cdk/aws-ecs';
+import { Cluster, FargatePlatformVersion, FargateService, IEcsLoadBalancerTarget, PropagatedTagSource } from '@aws-cdk/aws-ecs';
 import { CfnOutput, Construct, Stack } from '@aws-cdk/core';
 
 import { CacclTaskDef } from './taskdef';
@@ -35,6 +35,7 @@ export class CacclService extends Construct {
       circuitBreaker: {
         rollback: true,
       },
+      propagateTags: PropagatedTagSource.SERVICE,
     });
 
     // this is the thing that gets handed off to the load balancer

--- a/cdk/lib/service.ts
+++ b/cdk/lib/service.ts
@@ -26,7 +26,7 @@ export class CacclService extends Construct {
 
     this.ecsService = new FargateService(this, 'FargateService', {
       cluster,
-      platformVersion: FargatePlatformVersion.VERSION1_3,
+      platformVersion: FargatePlatformVersion.VERSION1_4,
       securityGroup: sg,
       taskDefinition: taskDef.taskDef,
       desiredCount: taskCount,

--- a/cdk/lib/stack.ts
+++ b/cdk/lib/stack.ts
@@ -28,7 +28,7 @@ export interface CacclDeployStackProps extends StackProps {
   dbOptions?: CacclDbOptions;
   bastionAmiMap?: { [key: string]: string; };
   scheduledTasks?: { [key: string]: CacclScheduledTask };
-  targetDeregistrationDelay?: number;
+  targetDeregistrationDelay?: number; // in seconds
   firewallSgId?: string;
 }
 

--- a/cdk/lib/stack.ts
+++ b/cdk/lib/stack.ts
@@ -28,6 +28,7 @@ export interface CacclDeployStackProps extends StackProps {
   dbOptions?: CacclDbOptions;
   bastionAmiMap?: { [key: string]: string; };
   scheduledTasks?: { [key: string]: CacclScheduledTask };
+  targetDeregistrationDelay?: number;
 }
 
 export class CacclDeployStack extends Stack {
@@ -119,6 +120,7 @@ export class CacclDeployStack extends Stack {
       certificateArn: props.certificateArn,
       loadBalancerTarget: service.loadBalancerTarget,
       albLogBucketName: props.albLogBucketName,
+      targetDeregistrationDelay: props.targetDeregistrationDelay,
       vpc,
       sg,
     });

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "caccl-deploy",
-  "version": "0.10.3",
+  "version": "0.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "caccl-deploy",
-      "version": "0.10.3",
+      "version": "0.11.0",
       "license": "ISC",
       "dependencies": {
         "@aws-cdk/aws-cloudwatch": "~1.122.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "caccl-deploy",
-  "version": "0.10.3",
+  "version": "0.11.0",
   "description": "A cli tool for managing ECS/Fargate app deployments",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Five small issues mixed together here, plus formatting fixes:
- adding a configuration setting to control the load balancer target deregistration delay. 
- moving from fargate platform version 1.3 to 1.4, details on platform changes are [here](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform-linux-fargate.html#platform-version-1-4)
- tweaking the threshold settings for the docdb cursor timeout alarm
- making resource tags propagate from the ecs service to the fargate tasks (to allow proper cost tracking)
- add importing of an external security group, i.e. for use as a firewall