### PR TITLE
AWS DocDB does not support retryWrites 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- task role now gets SES permissions to send email
+
 ### Modified
 
 - dropped node v12 and v14 from testing matrix; added v20

--- a/bin/docdb.sh
+++ b/bin/docdb.sh
@@ -92,9 +92,9 @@ DB_PASSWORD=`aws secretsmanager get-secret-value --secret-id $DB_PASSWORD_SECRET
 version_four="4.0.0"
 if [ "$(printf '%s\n' "$version_four" "$MONGO_VERSION" | sort -V | head -n1)" = "$version_four" ]; then
     echo "Using mongo > v4"
-    MONGO_OPTIONS="--tls --tlsAllowInvalidHostnames --tlsAllowInvalidCertificates"
+    MONGO_OPTIONS="--tls --tlsAllowInvalidHostnames --tlsAllowInvalidCertificates --retryWrites=false"
 else
-    MONGO_OPTIONS="--ssl --sslAllowInvalidHostnames --sslAllowInvalidCertificates"
+    MONGO_OPTIONS="--ssl --sslAllowInvalidHostnames --sslAllowInvalidCertificates --retryWrites=false"
 fi
 
 # we need the bastion host's availability zone and public ip to copy our key there and set up the ssh tunnel

--- a/cdk/lib/db.ts
+++ b/cdk/lib/db.ts
@@ -231,7 +231,7 @@ export class CacclDocDb extends CacclDbBase {
     appEnv.addEnvironmentVar('MONGO_HOST', `${this.host}:${this.port}`);
     appEnv.addEnvironmentVar(
       'MONGO_OPTIONS',
-      'tls=true&tlsAllowInvalidCertificates=true',
+      'tls=true&tlsAllowInvalidCertificates=true&retryWrites=False',
     );
     appEnv.addSecret(
       'MONGO_PASS',

--- a/cdk/lib/taskdef.ts
+++ b/cdk/lib/taskdef.ts
@@ -1,6 +1,7 @@
 import {
   aws_ecs as ecs,
   aws_logs as logs,
+  aws_iam as iam,
   Stack,
   RemovalPolicy,
   CfnOutput,
@@ -62,6 +63,14 @@ export class CacclTaskDef extends Construct {
       cpu: taskCpu,
       memoryLimitMiB: taskMemory,
     });
+
+    const sendEmailPolicy = new iam.PolicyStatement({
+      actions: ['ses:SendEmail', 'ses:SendRawEmail'],
+      resources: ['*'],
+    });
+
+    this.taskDef.addToTaskRolePolicy(sendEmailPolicy);
+    this.appOnlyTaskDef.addToTaskRolePolicy(sendEmailPolicy);
 
     // params for the fargate service's app container
     const appContainerParams = {


### PR DESCRIPTION
The latest MongoDB drivers support retry writes, but AWS DocumentDB does not yet support it.
This pull is to allow using newer Mongo DB drivers with existing AWS DocumentDB.

"Starting with MongoDB 4.2 compatible drivers, retryable writes is enabled by default. However, Amazon DocumentDB does not currently support retryable writes."

[https://docs.aws.amazon.com/do…cumentdb/latest/developerguide/functional-differences.html#functional-differences.retryable-writes](https://docs.aws.amazon.com/documentdb/latest/developerguide/functional-differences.html#functional-differences.retryable-writes)